### PR TITLE
Problem with constraint length of the primary key fixed

### DIFF
--- a/Database/Schema/SybaseGrammar.php
+++ b/Database/Schema/SybaseGrammar.php
@@ -36,7 +36,7 @@ class SybaseGrammar extends Grammar {
      */
     public function compileTableExists()
     {
-        return "SELECT * FROM sysobjects WHERE type = 'U' AND name = '?'";
+        return "SELECT * FROM sysobjects WHERE type = 'U' AND name = ?";
     }
 
     /**
@@ -106,9 +106,16 @@ class SybaseGrammar extends Grammar {
 
         $table = $this->wrapTable($blueprint);
 
+        // Verify if constraint length is lower to 30 characters.
+        if (strlen($command->index) > 30) {
+            $constraint = substr($command->index, 0, 30);
+        } else {
+            $constraint = $command->index;
+        }
+
         return "
             ALTER TABLE {$table}
-            ADD CONSTRAINT {$command->index}
+            ADD CONSTRAINT {$constraint}
             PRIMARY KEY ({$columns})";
     }
 


### PR DESCRIPTION
The constraints of the primary keys no have restrictions to length and that cause problems in migrating, to resolve that, i added a verification in length of the constraint to not pass 30 characters.