### PR TITLE
Rewittren the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ return [
         ...
 
         'sybase' => [
-            'driver' => 'sqlsrv',
+            'driver' => 'sybasease',
             'host' => env('DB_HOST', 'sybase.myserver.com'),
             'port' => env('DB_PORT', '5000'),
             'database' => env('DB_DATABASE', 'mydatabase'),
             'username' => env('DB_USERNAME', 'user'),
             'password' => env('DB_PASSWORD', 'password'),
-            'charset' => 'utf8',
+            'charset' => 'utf8', // Experimental yet, prefer use the `DB_CHARSET` and `APPLICATION_CHARSET`
             'prefix' => '',
         ],
 
@@ -105,6 +105,22 @@ The file is usualy found in **/etc/freetds/freetds.conf**. Set the configuration
 [global]
     # TDS protocol version
     tds version = 5.0
+```
+
+## Configuring the charset between the database and the application
+To configure the charset between the database and the application, add the fields `DB_CHARSET` and `APPLICATION_CHARSET` in `.env` file, see the following example:
+
+```env
+DB_CHARSET=CP850
+APPLICATION_CHARSET=UTF8
+```
+## Configuring the cache
+As the library consults table information whenever it receives a request, caching can be used to avoid excessive queries
+
+To use the cache, add the fields `SYBASE_CACHE_COLUMNS` and `SYBASE_CACHE_COLUMNS_TIME` to the `.env` file, see the following example:
+```dotenv
+SYBASE_CACHE_COLUMNS=true
+SYBASE_CACHE_COLUMNS_TIME=3600 # cache table information by `3600` seconds
 ```
 
 ## Setting to use numeric data type

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
         {
             "name": "Ademir Mazer Junior",
             "email": "ademir.mazer.jr@gmail.com"
+        },
+        {
+            "name": "Matheus Bueno Bartkevicius",
+            "email": "matheusbartkev@gmail.com"
         }
     ],
     "support": {

--- a/src/Database/Connector.php
+++ b/src/Database/Connector.php
@@ -6,5 +6,18 @@ use Illuminate\Database\Connectors\SqlServerConnector;
 
 class Connector extends SqlServerConnector
 {
-    //
+    public function connect(array $config)
+    {
+        $options = $this->getOptions($config);
+
+        $connection = $this->createConnection($this->getDsn($config), $config, $options);
+
+        if(array_key_exists('charset', $config) && $config['charset'] != '') {
+            $connection->prepare("set char_convert '{$config['charset']}'")->execute();
+        }
+
+        $this->configureIsolationLevel($connection, $config);
+
+        return $connection;
+    }
 }

--- a/src/Database/Query/Grammar.php
+++ b/src/Database/Query/Grammar.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Query\Grammars\Grammar as IlluminateGrammar;
 class Grammar extends IlluminateGrammar
 {
     /**
-     * All the available clause operators.
+     * All of the available clause operators.
      *
      * @var array
      */
@@ -21,14 +21,14 @@ class Grammar extends IlluminateGrammar
     /**
      * Builder for query.
      *
-     * @var Builder
+     * @var \Illuminate\Database\Query\Builder
      */
     protected $builder;
 
     /**
      * Get the builder.
      *
-     * @return Builder
+     * @return \Illuminate\Database\Query\Builder
      */
     public function getBuilder()
     {
@@ -38,7 +38,7 @@ class Grammar extends IlluminateGrammar
     /**
      * Compile a select query into SQL.
      *
-     * @param Builder $query
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @return string
      */
     public function compileSelect(Builder $query)
@@ -51,15 +51,196 @@ class Grammar extends IlluminateGrammar
     }
 
     /**
+     * Currently INSERT and UPDATE do not have "JOIN" to receive parameters from other tables, for example:
+     *
+     * A::query()
+     *   ->join('B', 'B.id', '=', 1)
+     *   ->insert([
+     *       'name' => DB::raw('B.name'),
+     *       'another_column' => 'another column',
+     *   ]));
+     *
+     * doesn't gerenerate the correct query:
+     *
+     *  INSERT INTO A (name, another_column)
+     *  SELECT B.name, 'another column'
+     *  FROM B
+     *  WHERE B.id = 1
+     *
+     */
+    /**
+     * Compile an insert statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileInsert(Builder $query, array $values)
+    {
+        $this->builder = $query;
+        $this->builder->values = $values;
+
+        // Essentially we will force every insert to be treated as a batch insert which
+        // simply makes creating the SQL easier for us since we can utilize the same
+        // basic routine regardless of an amount of records given to us to insert.
+        $table = $this->wrapTable($query->from);
+
+        if (empty($values)) {
+            return "insert into {$table} default values";
+        }
+
+        if (! is_array(reset($values))) {
+            $values = [$values];
+        }
+
+        $columns = $this->columnize(array_keys(reset($values)));
+
+        // We need to build a list of parameter place-holders of values that are bound
+        // to the query. Each insert should have the exact same number of parameter
+        // bindings so we will loop through the record and parameterize them all.
+        $parameters = collect($values)->map(function ($record) {
+            return 'SELECT '.$this->parameterize($record);
+        })->implode(' UNION ALL ');
+
+        return "insert into $table ($columns) $parameters";
+    }
+
+    /**
+     * Compile an update statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $values
+     * @return string
+     */
+    public function compileUpdate(Builder $query, array $values)
+    {
+        $this->builder = $query;
+        $this->builder->set = $values;
+
+        $components = $this->compileComponents($query);
+
+        $table = $this->wrapTable($query->from);
+
+        $columns = $this->compileUpdateColumns($query, $values);
+
+        $where = $this->compileWheres($query);
+
+
+        return trim(
+            isset($query->joins)
+                ? $this->compileUpdateWithJoins($query, $table, $columns, $where)
+                : $this->compileUpdateWithoutJoins($query, $table, $columns, $where)
+        );
+    }
+
+    /**
+     * Compile a delete statement into SQL.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return string
+     */
+    public function compileDelete(Builder $query)
+    {
+        $this->builder = $query;
+
+        $table = $this->wrapTable($query->from);
+
+        $where = $this->compileWheres($query);
+
+        return trim(
+            isset($query->joins)
+                ? $this->compileDeleteWithJoins($query, $table, $where)
+                : $this->compileDeleteWithoutJoins($query, $table, $where)
+        );
+    }
+
+    /**
+     * Compile the "select *" portion of the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  array  $columns
+     * @return string
+     */
+    protected function compileColumns(Builder $query, $columns)
+    {
+        if (! is_null($query->aggregate)) {
+            return;
+        }
+
+        $select = $query->distinct ? 'select distinct ' : 'select ';
+
+        // If there is a limit on the query, but not an offset, we will add the
+        // top clause to the query, which serves as a "limit" type clause
+        // within the SQL Server system similar to the limit keywords available
+        // in MySQL.
+        if ($query->limit > 0 && $query->offset <= 0) {
+            $select .= 'top '.$query->limit.' ';
+        }
+
+        return $select.$this->columnize($columns);
+    }
+
+    /**
+     * Compile the "from" portion of the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  string  $table
+     * @return string
+     */
+    protected function compileFrom(Builder $query, $table)
+    {
+        $from = parent::compileFrom($query, $table);
+
+        if (is_string($query->lock)) {
+            return $from.' '.$query->lock;
+        }
+
+        if (! is_null($query->lock)) {
+            return $from.' with(rowlock,'.
+                ($query->lock ? 'updlock,' : '').'holdlock)';
+        }
+
+        return $from;
+    }
+
+    /**
+     * Compile the "limit" portions of the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  int  $limit
+     * @return string
+     */
+    protected function compileLimit(Builder $query, $limit)
+    {
+        return '';
+    }
+
+    /**
+     * Compile the "offset" portions of the query.
+     *
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @param  int  $offset
+     * @return string
+     */
+    protected function compileOffset(Builder $query, $offset)
+    {
+        if($offset > 0) {
+            return 'rows offset '.$offset;
+        }
+
+        return '';
+    }
+
+    /**
      * Compile a truncate table statement into SQL.
      *
-     * @param Builder $query
+     * @param  \Illuminate\Database\Query\Builder  $query
      * @return array
      */
     public function compileTruncate(Builder $query)
     {
         return [
-            'truncate table ' . $this->wrapTable($query->from) => [],
+            'truncate table '.$this->wrapTable($query->from) => [],
         ];
     }
 
@@ -74,82 +255,9 @@ class Grammar extends IlluminateGrammar
     }
 
     /**
-     * Compile the "select *" portion of the query.
-     *
-     * @param Builder $query
-     * @param array $columns
-     * @return string
-     */
-    protected function compileColumns(Builder $query, $columns)
-    {
-        if (!is_null($query->aggregate)) {
-            return '';
-        }
-
-        $select = $query->distinct ? 'select distinct ' : 'select ';
-
-        // If there is a limit on the query, but not an offset, we will add the
-        // top clause to the query, which serves as a "limit" type clause
-        // within the SQL Server system similar to the limit keywords available
-        // in MySQL.
-        if ($query->limit > 0 && $query->offset <= 0) {
-            $select .= 'top ' . $query->limit . ' ';
-        }
-
-        return $select . $this->columnize($columns);
-    }
-
-    /**
-     * Compile the "from" portion of the query.
-     *
-     * @param Builder $query
-     * @param string $table
-     * @return string
-     */
-    protected function compileFrom(Builder $query, $table)
-    {
-        $from = parent::compileFrom($query, $table);
-
-        if (is_string($query->lock)) {
-            return $from . ' ' . $query->lock;
-        }
-
-        if (!is_null($query->lock)) {
-            return $from . ' with(rowlock,' .
-                ($query->lock ? 'updlock,' : '') . 'holdlock)';
-        }
-
-        return $from;
-    }
-
-    /**
-     * Compile the "limit" portions of the query.
-     *
-     * @param Builder $query
-     * @param int $limit
-     * @return string
-     */
-    protected function compileLimit(Builder $query, $limit)
-    {
-        return '';
-    }
-
-    /**
-     * Compile the "offset" portions of the query.
-     *
-     * @param Builder $query
-     * @param int $offset
-     * @return string
-     */
-    protected function compileOffset(Builder $query, $offset)
-    {
-        return '';
-    }
-
-    /**
      * Wrap a single string in keyword identifiers.
      *
-     * @param string $value
+     * @param  string  $value
      * @return string
      */
     protected function wrapValue($value)
@@ -158,6 +266,6 @@ class Grammar extends IlluminateGrammar
             return $value;
         }
 
-        return '[' . str_replace(']', ']]', $value) . ']';
+        return '['.str_replace(']', ']]', $value).']';
     }
 }

--- a/src/SybaseServiceProvider.php
+++ b/src/SybaseServiceProvider.php
@@ -16,7 +16,7 @@ class SybaseServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        IlluminateConnection::resolverFor('sqlsrv', function (
+        IlluminateConnection::resolverFor('sybasease', function (
             $connection,
             $database,
             $prefix,
@@ -30,7 +30,7 @@ class SybaseServiceProvider extends ServiceProvider
             );
         });
 
-        $this->app->bind('db.connector.sqlsrv', function ($app) {
+        $this->app->bind('db.connector.sybasease', function ($app) {
             return new Connector();
         });
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -42,13 +42,13 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
             $config->set('database.default', 'sybase');
             $config->set('database.connections.sybase', [
-                'driver' => 'sqlsrv',
+                'driver' => 'sybasease',
                 'host' => env('DB_HOST', 'localhost'),
                 'port' => env('DB_PORT', '1433'),
                 'database' => env('DB_DATABASE', 'forge'),
                 'username' => env('DB_USERNAME', 'forge'),
                 'password' => env('DB_PASSWORD', ''),
-                'charset' => 'utf8',
+                // 'charset' => 'utf8',
                 'prefix' => '',
                 'prefix_indexes' => true,
                 'options' => array(\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
                 'database' => env('DB_DATABASE', 'forge'),
                 'username' => env('DB_USERNAME', 'forge'),
                 'password' => env('DB_PASSWORD', ''),
-                // 'charset' => 'utf8',
+                'charset' => 'utf8',
                 'prefix' => '',
                 'prefix_indexes' => true,
                 'options' => array(\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION)


### PR DESCRIPTION
Rewriting the library for cleaner code and features that the previous one did not support

## Changes

* Rewriting the code
* Correcting the logic
* Adding support for Laravel ORM features: `with`, `whereIn`, `whereBetween`, ...
* Changing the driver from `sqlsrv` to `sybasease` to avoid conflicts
* Adding the possibility for the user to use `charset` for conversion (experimental still, breaking into unions involving tables from different databases)
